### PR TITLE
inject grammar into source.coffee

### DIFF
--- a/Syntaxes/Javascript (JSX).tmLanguage
+++ b/Syntaxes/Javascript (JSX).tmLanguage
@@ -5,7 +5,7 @@
 	<key>fileTypes</key>
 	<array/>
 	<key>injectionSelector</key>
-	<string>L:(source.js - comment.* - string.*)</string>
+	<string>L:(source.js - comment.* - string.*), L:(source.coffee - comment.* - string.*)</string>
 	<key>name</key>
 	<string>Javascript (JSX)</string>
 	<key>patterns</key>


### PR DESCRIPTION
Turns this: 

![image](https://cloud.githubusercontent.com/assets/351038/19627793/d6a8cecc-994f-11e6-8da4-20cef7c069fe.png)

Into this:

![image](https://cloud.githubusercontent.com/assets/351038/19627797/f58721fe-994f-11e6-82fc-3a7102f7427d.png)

Not sure if this is the recommended way of injecting it into 2 grammars. (there might be a more concise way of writing the selector?)

Also, the injected grammar includes `source.js`, which when injected into `source.coffee`, actually has to be `source.coffee`. Maybe there's a way of referring to the root grammar? (cc: @infininight)

